### PR TITLE
CCM-814, CCM-816, CCM-815

### DIFF
--- a/azure/azure-pr-pipeline.yml
+++ b/azure/azure-pr-pipeline.yml
@@ -32,6 +32,7 @@ extends:
     service_name: ${{ variables.service_name }}
     short_service_name: ${{ variables.short_service_name }}
     service_base_path: ${{ variables.service_base_path }}
+    hosted_target_connection_path_suffix: '{requestPath}'
     apigee_deployments:
       - environment: internal-dev
         post_deploy:

--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -30,6 +30,7 @@ extends:
     service_name: ${{ variables.service_name }}
     short_service_name: ${{ variables.short_service_name }}
     service_base_path: ${{ variables.service_base_path }}
+    hosted_target_connection_path_suffix: '{requestPath}'
     apigee_deployments:
       - environment: internal-dev
         post_deploy:

--- a/proxies/sandbox/apiproxy/policies/AssignMessage.MessageBatches.Create.Request.xml
+++ b/proxies/sandbox/apiproxy/policies/AssignMessage.MessageBatches.Create.Request.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.MessageBatches.Create.Request">
+    <DisplayName>AssignMessage.MessageBatches.Create.Request</DisplayName>    
+    <Properties/>
+    <AssignTo createNew="false" transport="http" type="request"/>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <Set>
+        <Payload contentType="application/json" variablePrefix="%" variableSuffix="#">%data.payload#</Payload>
+        <Headers>
+            <Header name="Content-Type">application/json</Header>
+        </Headers>
+        <Verb>POST</Verb>
+    </Set>
+</AssignMessage>

--- a/proxies/sandbox/apiproxy/policies/AssignMessage.MessageBatches.Create.Response.xml
+++ b/proxies/sandbox/apiproxy/policies/AssignMessage.MessageBatches.Create.Response.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage async="false" continueOnError="false" enabled="true" name="AssignMessage.MessageBatches.Create.Response">
+    <DisplayName>AssignMessage.MessageBatches.Create.Response</DisplayName>    
+    <Properties/>
+    <AssignTo createNew="true" transport="http" type="response"/>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <Set>
+        <Payload contentType="application/json" variablePrefix="%" variableSuffix="#">
+            {
+                "data" : {
+                    "type" : "MessageBatch",
+                    "id" : "%data.requestId#",
+                    "attributes" : {
+                        "messageBatchReference" : "%data.messageBatchReference#"
+                    }
+                }
+            }
+        </Payload>
+        <Headers>
+            <Header name="Content-Type">application/json</Header>
+        </Headers>
+        <StatusCode>201</StatusCode>
+    </Set>
+</AssignMessage>

--- a/proxies/sandbox/apiproxy/policies/ExtractVariables.MessageBatches.Create.Response.xml
+++ b/proxies/sandbox/apiproxy/policies/ExtractVariables.MessageBatches.Create.Response.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ExtractVariables async="false" continueOnError="false" enabled="true" name="ExtractVariables.MessageBatches.Create.Response">
+    <VariablePrefix>data</VariablePrefix>
+    <Source>response</Source>
+    <JSONPayload>
+        <Variable name="requestId" type="string">
+            <JSONPath>$.requestId</JSONPath>
+        </Variable>        
+    </JSONPayload>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</ExtractVariables>

--- a/proxies/sandbox/apiproxy/policies/JavaScript.MessageBatches.Create.Request.xml
+++ b/proxies/sandbox/apiproxy/policies/JavaScript.MessageBatches.Create.Request.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript async="false" continueOnError="false" enabled="true" timeLimit="200" name="JavaScript.MessageBatches.Create.Request">
+    <DisplayName>JavaScript.MessageBatches.Create.Request</DisplayName>
+    <ResourceURL>jsc://MessageBatches.Create.Request.js</ResourceURL>
+</Javascript>

--- a/proxies/sandbox/apiproxy/policies/RaiseFault.400BackendException.DuplicateRequestItemRefIds.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.400BackendException.DuplicateRequestItemRefIds.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.400BackendException.DuplicateRequestItemRefIds">
+    <DisplayName>RaiseFault.400BackendException.DuplicateRequestItemRefIds</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <StatusCode>400</StatusCode>
+            <ReasonPhrase>Bad Request</ReasonPhrase>
+            <Payload contentType="application/vnd.api+json" variablePrefix="@" variableSuffix="#">
+                {
+                    "errors" : [
+                        {
+                            "id" : "CM_INVALID_VALUE",
+                            "links" : {
+                                "about" : "https://digital.nhs.uk/developer/api-catalogue/communications-manager"
+                            },
+                            "status" : "400",
+                            "title" : "Duplicate value",
+                            "description" : "The property at the specified location is a duplicate, duplicated values are not allowed.",
+                            "source" : {
+                                "pointer" : "/data/attributes/messages"
+                            }
+                        }
+                    ]
+                }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/sandbox/apiproxy/policies/RaiseFault.400BackendException.MissingDataArray.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.400BackendException.MissingDataArray.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.400BackendException.MissingDataArray">
+    <DisplayName>RaiseFault.400BackendException.MissingDataArray</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <StatusCode>400</StatusCode>
+            <ReasonPhrase>Bad Request</ReasonPhrase>
+            <Payload contentType="application/vnd.api+json" variablePrefix="@" variableSuffix="#">
+                {
+                    "errors" : [
+                        {
+                            "id" : "CM_INVALID_VALUE",
+                            "links" : {
+                                "about" : "https://digital.nhs.uk/developer/api-catalogue/communications-manager"
+                            },
+                            "status" : "400",
+                            "title" : "Invalid value",
+                            "description" : "The property at the specified location does not allow this value.",
+                            "source" : {
+                                "pointer" : "/data/attributes/messages"
+                            }
+                        }
+                    ]
+                }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/sandbox/apiproxy/policies/RaiseFault.400BackendException.MissingRequestRefId.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.400BackendException.MissingRequestRefId.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.400BackendException.MissingRequestRefId">
+    <DisplayName>RaiseFault.400BackendException.MissingRequestRefId</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <StatusCode>400</StatusCode>
+            <ReasonPhrase>Bad Request</ReasonPhrase>
+            <Payload contentType="application/vnd.api+json" variablePrefix="@" variableSuffix="#">
+                {
+                    "errors" : [
+                        {
+                            "id" : "CM_INVALID_VALUE",
+                            "links" : {
+                                "about" : "https://digital.nhs.uk/developer/api-catalogue/communications-manager"
+                            },
+                            "status" : "400",
+                            "title" : "Invalid value",
+                            "description" : "The property at the specified location does not allow this value.",
+                            "source" : {
+                                "pointer" : "/data/attributes/messageBatchReference"
+                            }
+                        }
+                    ]
+                }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/sandbox/apiproxy/policies/RaiseFault.400BackendException.MissingSendingGroupId.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.400BackendException.MissingSendingGroupId.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.400BackendException.MissingSendingGroupId">
+    <DisplayName>RaiseFault.400BackendException.MissingSendingGroupId</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <StatusCode>400</StatusCode>
+            <ReasonPhrase>Bad Request</ReasonPhrase>
+            <Payload contentType="application/vnd.api+json" variablePrefix="@" variableSuffix="#">
+                {
+                    "errors" : [
+                        {
+                            "id" : "CM_INVALID_VALUE",
+                            "links" : {
+                                "about" : "https://digital.nhs.uk/developer/api-catalogue/communications-manager"
+                            },
+                            "status" : "400",
+                            "title" : "Invalid value",
+                            "description" : "The property at the specified location does not allow this value.",
+                            "source" : {
+                                "pointer" : "/data/attributes/routingPlanId"
+                            }
+                        }
+                    ]
+                }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/sandbox/apiproxy/policies/RaiseFault.404InvalidRoutingPlan.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.404InvalidRoutingPlan.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.404InvalidRoutingPlan">
+    <DisplayName>RaiseFault.404InvalidRoutingPlan</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <StatusCode>404</StatusCode>
+            <ReasonPhrase>Not Found</ReasonPhrase>
+            <Payload contentType="application/vnd.api+json" variablePrefix="@" variableSuffix="#">
+                {
+                    "errors" : [
+                        {
+                            "id" : "CM_NO_SUCH_ROUTING_PLAN",
+                            "links" : {
+                                "about" : "https://digital.nhs.uk/developer/api-catalogue/communications-manager"
+                            },
+                            "status" : "404",
+                            "title" : "No such routing plan",
+                            "description" : "The routing plan specified either does not exist or is not in a usable state.",
+                            "source" : {
+                                "pointer" : "/data/attributes/routingPlanId"
+                            }
+                        }
+                    ]
+                }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/sandbox/apiproxy/policies/RaiseFault.404NotFound.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.404NotFound.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.404NotFound">
+    <DisplayName>RaiseFault.404NotFound</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <StatusCode>404</StatusCode>
+            <ReasonPhrase>Not Found</ReasonPhrase>
+            <Payload contentType="application/vnd.api+json" variablePrefix="@" variableSuffix="#">
+                {
+                    "errors" : [
+                        {
+                            "id" : "CM_NOT_FOUND",
+                            "links" : {
+                                "about" : "https://digital.nhs.uk/developer/api-catalogue/communications-manager"
+                            },
+                            "status" : "404",
+                            "title" : "Resource not found",
+                            "description" : "The resource at the requested URI was not found."
+                        }
+                    ]
+                }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/sandbox/apiproxy/resources/jsc/MessageBatches.Create.Request.js
+++ b/proxies/sandbox/apiproxy/resources/jsc/MessageBatches.Create.Request.js
@@ -1,0 +1,34 @@
+const content = context.getVariable("request.content")
+const data = JSON.parse(content).data
+var messages = null;
+var routingPlanId = null;
+var messageBatchReference = null;
+
+if (data && data.attributes) {
+    routingPlanId = data.attributes.routingPlanId;
+    messageBatchReference = data.attributes.messageBatchReference;
+
+    if (data.attributes.messages) {
+        messages = [];
+        data.attributes.messages.forEach((message) => {
+            if (message) {
+                messages.push({
+                    nhsNumber           : message.recipient ? message.recipient.nhsNumber : null,
+                    dateOfBirth         : message.recipient ? message.recipient.dateOfBirth : null,
+                    requestItemRefId    : message.messageReference,
+                    personalisation     : message.personalisation
+                });
+            }
+        });
+    }
+}
+
+context.setVariable("data.payload", JSON.stringify({
+    "sendingGroupId" : routingPlanId,
+    "requestRefId" : messageBatchReference,
+    "data" : messages
+}));
+context.setVariable("data.messageBatchReference", messageBatchReference);
+
+context.setVariable("target.copy.pathsuffix", true);
+context.setVariable("requestPath", "/api/v1/send");

--- a/proxies/sandbox/apiproxy/targets/sandbox.xml
+++ b/proxies/sandbox/apiproxy/targets/sandbox.xml
@@ -1,7 +1,80 @@
 <TargetEndpoint name="sandbox">
     <Description/>
     <FaultRules/>
-    <Flows/>
+    <Flows>
+        <Flow name="CreateMessageBatchEndpoint">
+            <Description>Handle create message batch</Description>
+            <Request>
+                <Step>
+                    <Name>JavaScript.MessageBatches.Create.Request</Name>
+                </Step>
+                <Step>
+                    <Name>AssignMessage.MessageBatches.Create.Request</Name>
+                </Step>
+            </Request>
+            <Response>
+                <Step>
+                    <Name>ExtractVariables.MessageBatches.Create.Response</Name>
+                </Step>
+                <Step>
+                    <Name>AssignMessage.MessageBatches.Create.Response</Name>
+                </Step>
+            </Response>
+            <Condition>
+                (proxy.pathsuffix MatchesPath "/v1/message-batches") and (request.verb = "POST")
+            </Condition>
+        </Flow>
+    </Flows>
+    <FaultRules>
+        <FaultRule name="invalid_routing_plan">
+            <Step>
+                <Name>RaiseFault.404InvalidRoutingPlan</Name>
+            </Step>
+            <Condition>
+                response.status.code = 404 and response.content Like "*Routing Config does not exist for sendingGroupId*"
+            </Condition>
+        </FaultRule>
+        <FaultRule name="not_found">
+            <Step>
+                <Name>RaiseFault.404NotFound</Name>
+            </Step>
+            <Condition>
+                response.status.code = 404
+            </Condition>
+        </FaultRule>
+        <FaultRule name="backend_duplicate_requestItemRefIds">
+            <Step>
+                <Name>RaiseFault.400BackendException.DuplicateRequestItemRefIds</Name>
+            </Step>
+            <Condition>
+                response.status.code = 400 and response.content Like "*Duplicate requestItemRefIds*"
+            </Condition>
+        </FaultRule>
+        <FaultRule name="backend_missing_sendingGroupId">
+            <Step>
+                <Name>RaiseFault.400BackendException.MissingSendingGroupId</Name>
+            </Step>
+            <Condition>
+                response.status.code = 400 and response.content Like "*Missing sendingGroupId*"
+            </Condition>
+        </FaultRule>
+        <FaultRule name="backend_missing_requestRefId">
+            <Step>
+                <Name>RaiseFault.400BackendException.MissingRequestRefId</Name>
+            </Step>
+            <Condition>
+                response.status.code = 400 and response.content Like "*Missing requestRefId*"
+            </Condition>
+        </FaultRule>
+        <FaultRule name="backend_missing_data_array">
+            <Step>
+                <Name>RaiseFault.400BackendException.MissingDataArray</Name>
+            </Step>
+            <Condition>
+                response.status.code = 400 and response.content Like "*Missing data array*"
+            </Condition>
+        </FaultRule>
+    </FaultRules>
     <PostFlow name="PostFlow">
         <Request/>
         <Response/>


### PR DESCRIPTION
## Summary

CCM-814, CCM-816, CCM-815
    
Adds proxying of POST /v1/message-batches to POST /api/v1/send on the
backend.

Adds support for handling of these exceptions thrown by the backend
service:

* 400 - Duplicate requestItemRefIds
* 400 - Missing data array
* 400 - Missing requestRefId
* 400 - missing sendingGroupId
* 404 - Invalid routing plan
* 404 - Generic error

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
