### PR TITLE
CCM-820

### DIFF
--- a/azure/azure-build-pipeline.yml
+++ b/azure/azure-build-pipeline.yml
@@ -20,7 +20,7 @@ resources:
     - repository: common
       type: github
       name: NHSDigital/api-management-utils
-      ref: refs/heads/edge
+      ref: refs/heads/CCM-820-hosted-path-suffix
       endpoint: NHSDigital
 
 variables:

--- a/azure/azure-pr-pipeline.yml
+++ b/azure/azure-pr-pipeline.yml
@@ -8,7 +8,7 @@ resources:
     - repository: common
       type: github
       name: NHSDigital/api-management-utils
-      ref: refs/heads/edge
+      ref: refs/heads/CCM-820-hosted-path-suffix
       endpoint: NHSDigital
   pipelines:
   - pipeline: build_pipeline
@@ -32,7 +32,7 @@ extends:
     service_name: ${{ variables.service_name }}
     short_service_name: ${{ variables.short_service_name }}
     service_base_path: ${{ variables.service_base_path }}
-    hosted_target_connection_path_suffix: '{requestPath}'
+    hosted_target_connection_path_suffix: ${{ variables.hosted_target_connection_path_suffix }}
     apigee_deployments:
       - environment: internal-dev
         post_deploy:

--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -8,7 +8,7 @@ resources:
     - repository: common
       type: github
       name: NHSDigital/api-management-utils
-      ref: refs/heads/edge
+      ref: refs/heads/CCM-820-hosted-path-suffix
       endpoint: NHSDigital
   pipelines:
   - pipeline: build_pipeline
@@ -30,7 +30,7 @@ extends:
     service_name: ${{ variables.service_name }}
     short_service_name: ${{ variables.short_service_name }}
     service_base_path: ${{ variables.service_base_path }}
-    hosted_target_connection_path_suffix: '{requestPath}'
+    hosted_target_connection_path_suffix: ${{ variables.hosted_target_connection_path_suffix }}
     apigee_deployments:
       - environment: internal-dev
         post_deploy:

--- a/azure/project.yml
+++ b/azure/project.yml
@@ -6,3 +6,5 @@ variables:
     value: cm
   - name: service_base_path
     value: comms
+  - name: hosted_target_connection_path_suffix
+    value: '{requestpath}'

--- a/proxies/sandbox/apiproxy/policies/AssignMessage.MessageBatches.Create.Request.xml
+++ b/proxies/sandbox/apiproxy/policies/AssignMessage.MessageBatches.Create.Request.xml
@@ -4,6 +4,14 @@
     <Properties/>
     <AssignTo createNew="false" transport="http" type="request"/>
     <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <AssignVariable>
+        <Name>target.copy.pathsuffix</Name>
+        <Value>false</Value>
+    </AssignVariable>
+    <AssignVariable>
+        <Name>requestpath</Name>
+        <Value>/api/v1/send</Value>
+    </AssignVariable>
     <Set>
         <Payload contentType="application/json" variablePrefix="%" variableSuffix="#">%data.payload#</Payload>
         <Headers>

--- a/proxies/sandbox/apiproxy/policies/JavaScript.MessageBatches.Create.Request.xml
+++ b/proxies/sandbox/apiproxy/policies/JavaScript.MessageBatches.Create.Request.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Javascript async="false" continueOnError="false" enabled="true" timeLimit="200" name="JavaScript.MessageBatches.Create.Request">
+<Javascript async="false" continueOnError="false" enabled="true" timeLimit="1000" name="JavaScript.MessageBatches.Create.Request">
     <DisplayName>JavaScript.MessageBatches.Create.Request</DisplayName>
+    <Properties/>
     <ResourceURL>jsc://MessageBatches.Create.Request.js</ResourceURL>
 </Javascript>

--- a/proxies/sandbox/apiproxy/policies/RaiseFault.408RequestTimeout.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.408RequestTimeout.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.408RequestTimeout">
+    <DisplayName>RaiseFault.408RequestTimeout</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <StatusCode>408</StatusCode>
+            <ReasonPhrase>Request Timeout</ReasonPhrase>
+            <Payload contentType="application/vnd.api+json" variablePrefix="@" variableSuffix="#">
+                {
+                    "errors" : [
+                        {
+                            "id" : "CM_TIMEOUT",
+                            "links" : {
+                                "about" : "https://digital.nhs.uk/developer/api-catalogue/communications-manager"
+                            },
+                            "status" : "408",
+                            "title" : "Request timeout",
+                            "description" : "The service was unable to receive your request within the timeout period."
+                        }
+                    ]
+                }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/sandbox/apiproxy/policies/RaiseFault.504GatewayTimeout.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.504GatewayTimeout.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.504GatewayTimeout">
+    <DisplayName>RaiseFault.504GatewayTimeout</DisplayName>
+    <Properties/>
+    <FaultResponse>
+        <Set>
+            <Headers/>
+            <StatusCode>504</StatusCode>
+            <ReasonPhrase>Gateway Timeout</ReasonPhrase>
+            <Payload contentType="application/vnd.api+json" variablePrefix="@" variableSuffix="#">
+                {
+                    "errors" : [
+                        {
+                            "id" : "CM_TIMEOUT",
+                            "links" : {
+                                "about" : "https://digital.nhs.uk/developer/api-catalogue/communications-manager"
+                            },
+                            "status" : "504",
+                            "title" : "Unable to call service",
+                            "description" : "The downstream service has not responded within the configured timeout period."
+                        }
+                    ]
+                }
+            </Payload>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/sandbox/apiproxy/resources/jsc/MessageBatches.Create.Request.js
+++ b/proxies/sandbox/apiproxy/resources/jsc/MessageBatches.Create.Request.js
@@ -29,6 +29,3 @@ context.setVariable("data.payload", JSON.stringify({
     "data" : messages
 }));
 context.setVariable("data.messageBatchReference", messageBatchReference);
-
-context.setVariable("target.copy.pathsuffix", true);
-context.setVariable("requestPath", "/api/v1/send");

--- a/proxies/sandbox/apiproxy/targets/sandbox.xml
+++ b/proxies/sandbox/apiproxy/targets/sandbox.xml
@@ -1,6 +1,5 @@
 <TargetEndpoint name="sandbox">
     <Description/>
-    <FaultRules/>
     <Flows>
         <Flow name="CreateMessageBatchEndpoint">
             <Description>Handle create message batch</Description>
@@ -74,6 +73,18 @@
                 response.status.code = 400 and response.content Like "*Missing data array*"
             </Condition>
         </FaultRule>
+        <FaultRule name="backend_gateway_timeout">
+            <Step>
+                <Name>RaiseFault.504GatewayTimeout</Name>
+            </Step>
+            <Condition>fault.name = "GatewayTimeout" or response.status.code = 504</Condition>
+        </FaultRule>
+        <FaultRule name="backend_request_timeout">
+            <Step>
+                <Name>RaiseFault.408RequestTimeout</Name>
+            </Step>
+            <Condition>fault.name = "RequestTimeout" or response.status.code = 408</Condition>
+        </FaultRule>
     </FaultRules>
     <PostFlow name="PostFlow">
         <Request/>
@@ -95,6 +106,10 @@
         </Response>
     </PreFlow>
     <HTTPTargetConnection>
-      {{ HOSTED_TARGET_CONNECTION }}
+        {{ HOSTED_TARGET_CONNECTION }}
+        <Properties>
+            <!-- this is set to 2 seconds here to make it quicker to test, in live this should be 29 seconds -->
+            <Property name="io.timeout.millis">2000</Property>
+        </Properties>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/sandbox/app.js
+++ b/sandbox/app.js
@@ -128,6 +128,9 @@ app.get("/_ping", handlers.status);
 app.get("/_status", handlers.status);
 app.get("/health", handlers.status);
 app.post("/api/v1/send", handlers.batch_send);
+app.get("/_timeout", handlers.trigger_timeout);
+app.get("/_timeout_408", handlers.backend_408);
+app.get("/_timeout_504", handlers.backend_504);
 app.use(on_error)
 app.use(after_request);
 

--- a/sandbox/handlers.js
+++ b/sandbox/handlers.js
@@ -130,7 +130,36 @@ async function batch_send(req, res, next) {
     next();
 }
 
+async function trigger_timeout(req, res, next) {
+    let timeoutLength = 3000;
+
+    if (req.query.sleep) {
+        timeoutLength = parseInt(req.query.sleep);
+    }
+
+    setTimeout(() => {
+        res.status(200);
+        res.json({});
+        next();
+    }, timeoutLength);
+}
+
+async function backend_408(req, res, next) {
+    res.status(408);
+    res.send("408 Request Timeout");
+    next();
+}
+
+async function backend_504(req, res, next) {
+    res.status(504);
+    res.send("504 Gateway Timeout");
+    next();
+}
+
 module.exports = {
     status: status,
-    batch_send: batch_send
+    batch_send: batch_send,
+    trigger_timeout: trigger_timeout,
+    backend_408: backend_408,
+    backend_504: backend_504
 };

--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -146,10 +146,10 @@ paths:
           content:
             application/vnd.api+json:
               schema:
-                $ref: '#/components/schemas/ServiceTimeoutResponse'
+                $ref: '#/components/schemas/RequestTimeoutResponse'
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceTimeoutResponse'
+                $ref: '#/components/schemas/RequestTimeoutResponse'
           headers:
             X-Correlation-ID:
               schema:
@@ -234,6 +234,21 @@ paths:
                 multipleOf: 1
                 example: 5
               description: Time to wait between requests in seconds
+        '504':
+          description: Gateway Timeout
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/ServiceTimeoutResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceTimeoutResponse'
+          headers:
+            X-Correlation-ID:
+              schema:
+                type: string
+                pattern: 11C46F5F-CDEF-4865-94B2-0EE0EDCC26DA
+              description: 'The X-Correlation-ID from the request header, if supplied, mirrored back.'
       security: []
       servers:
         - url: 'https://sandbox.api.service.nhs.uk/comms'
@@ -611,9 +626,9 @@ components:
         - CM_NOT_ACCEPTABLE
       title: Enum_Error_NotAcceptable
       example: CM_NOT_ACCEPTABLE
-    ServiceTimeoutResponse:
+    RequestTimeoutResponse:
       type: object
-      title: Service timeout
+      title: Request timeout
       additionalProperties: false
       properties:
         errors:
@@ -642,12 +657,12 @@ components:
                 example: '408'
               title:
                 enum:
-                  - Unable to call service
-                example: Unable to call service
+                  - Request timeout
+                example: Request timeout
               detail:
                 enum:
-                  - The downstream service has not responded within the configured timeout period.
-                example: The downstream service has not responded within the configured timeout period.
+                  - The service was unable to receive your request within the timeout period.
+                example: The service was unable to receive your request within the timeout period.
     Enum_Error_Timeout:
       enum:
         - CM_TIMEOUT
@@ -831,3 +846,40 @@ components:
       enum:
         - CM_HEADERS_TOO_LARGE
       title: Enum_Error_HeadersTooLarge
+    ServiceTimeoutResponse:
+      type: object
+      title: Service timeout
+      additionalProperties: false
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          maxItems: 1
+          uniqueItems: true
+          items:
+            type: object
+            properties:
+              id:
+                $ref: '#/components/schemas/Enum_Error_Timeout'
+              links:
+                type: object
+                additionalProperties: false
+                properties:
+                  about:
+                    enum:
+                      - 'https://digital.nhs.uk/developer/api-catalogue/communications-manager'
+                    format: uri
+                    example: 'https://digital.nhs.uk/developer/api-catalogue/communications-manager'
+                minProperties: 1
+              status:
+                enum:
+                  - '504'
+                example: '504'
+              title:
+                enum:
+                  - Unable to call service
+                example: Unable to call service
+              detail:
+                enum:
+                  - The downstream service has not responded within the configured timeout period.
+                example: The downstream service has not responded within the configured timeout period.


### PR DESCRIPTION
## Summary
Adds support for both gateway and request timeouts. On the sandbox these trigger after 2 seconds.

Adds support for rethrowing 408 and 504 error responses received from the backend service.

Updated the spec to include the gateway timeout response from the API.

--

Adds an endpoint on the sandbox app that allows the backend timeout to be triggered : `GET /_timeout[?sleep=3000]`.

The optional sleep value is set to 3000 milliseconds by default. Passing an integer value into the call will control the amount of time the endpoint sleeps for before a response is made.

--

Adds an endpoint for testing the rethrow of 408 error responses from the backend service : `GET /_timeout_408`.

--

Adds an endpoint for testing the rethrow of 504 error responses from the backend service : `GET /_timeout_504`.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
