### PR TITLE
CCM-956

### DIFF
--- a/proxies/sandbox/apiproxy/targets/sandbox.xml
+++ b/proxies/sandbox/apiproxy/targets/sandbox.xml
@@ -90,7 +90,7 @@
             <Step>
                 <Name>RaiseFault.401Unauthorized</Name>
                 <Condition>
-                    request.header.Authorization = "Bearer InvalidMockToken"
+                    request.header.Authorization = "Bearer InvalidMockToken" or request.header.Prefer = "code=401"
                 </Condition>
             </Step>
             <Step>

--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -108,7 +108,23 @@ paths:
                 pattern: 11C46F5F-CDEF-4865-94B2-0EE0EDCC26DA
               description: 'The X-Correlation-ID from the request header, if supplied, mirrored back.'
         '401':
-          description: Unauthorized
+          description: |+
+            Your request was not authorized - you need to send a `Authorization` header with a valid `Bearer` token.
+
+            See the documentation on [how to generate a valid token](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication).
+
+            ### Sandbox
+
+            It is possible to trigger this error in the sandbox by sending the header `Prefer` with a value of `code=401`.
+
+            Here is an example curl request to trigger a `401`:
+
+            ```
+              curl -X GET \
+                --header "Accept: */*" \
+                --header "Prefer: code=401" \
+                https://sandbox.api.service.nhs.uk/comms/
+            ```
           content:
             application/vnd.api+json:
               schema:


### PR DESCRIPTION
## Summary
Adds documentation for the 401 response type, including a link to the instructions on how to generate a valid bearer token.

Adds the ability to trigger the 401 by sending a request with the header `Prefer` set to a value of `code=401` - this is to ensure that the documentation is consistent for end consumers.

## Reviews Required
* [ ] Dev
* [ ] Test
* [ ] Tech Author
* [x] Product Owner

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
