### PR TITLE
CCM-987- adds link to NHS Number info in existing spec 

### DIFF
--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -577,7 +577,7 @@ components:
           minLength: 10
           maxLength: 10
           example: '1234567890'
-          description: The NHS number of the recipient. This will be used to lookup the recipients details with the [Personal Demographics Service](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir).
+          description: The [NHS number](https://digital.nhs.uk/services/nhs-number) of the recipient. This will be used to lookup the recipients details with the [Personal Demographics Service](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir).
         dateOfBirth:
           type: string
           description: 'Date of birth in ISO-8601 format: YYYY-MM-DD.'


### PR DESCRIPTION
Adds a link to https://digital.nhs.uk/services/nhs-number for information when reference NHS Number in existing spec. Only 1 x ref to NHS number found.

## Summary
* Routine Change

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
