### PR TITLE
CCM-1290 - cleanup

### DIFF
--- a/proxies/shared/policies/AssignMessage.AuthenticationDetails.xml
+++ b/proxies/shared/policies/AssignMessage.AuthenticationDetails.xml
@@ -5,10 +5,8 @@
     <Set>
         <Headers>
             {% if ENVIRONMENT_TYPE == 'internal' %}
-                <Header name="X-Client-Id">13bff444-4e1e-4e45-92a9-5924e2d19b9c</Header>
                 <Header name="X-APIM-Application-Id">13bff444-4e1e-4e45-92a9-5924e2d19b9c</Header>
             {% else %}
-                <Header name="X-Client-Id">{developer.app.id}</Header>
                 <Header name="X-APIM-Application-Id">{developer.app.id}</Header>
             {% endif %}
         </Headers>


### PR DESCRIPTION
## Summary

Removes the X-Client-Id header from downstream requests.

This cannot be accepted and deployed until https://nhsd-git.digital.nhs.uk/riskstrat/communications-manager/-/merge_requests/377 has been promoted into production.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
