### PR TITLE
CCM-1135

### DIFF
--- a/proxies/shared/partials/Partial.Target.PreFlowRequest.xml
+++ b/proxies/shared/partials/Partial.Target.PreFlowRequest.xml
@@ -2,6 +2,9 @@
     <Name>JavaScript.SetResponseContentType</Name>
 </Step>
 <Step>
+    <Name>JavaScript.SetBackendCorrelationId</Name>
+</Step>
+<Step>
     <Name>AssignMessage.AddDefaultRequestPath</Name>
 </Step>
 <Step>

--- a/proxies/shared/policies/AssignMessage.MessageBatches.Create.Request.xml
+++ b/proxies/shared/policies/AssignMessage.MessageBatches.Create.Request.xml
@@ -17,6 +17,7 @@
         <Headers>
             <Header name="Content-Type">application/json</Header>
             <Header name="X-Idempotency-Key">{developer.app.id}-{data.messageBatchReference}</Header>
+            <Header name="X-Correlation-Id">{backendCorrelationId}</Header>
         </Headers>
         <Verb>POST</Verb>
     </Set>

--- a/proxies/shared/policies/JavaScript.SetBackendCorrelationId.xml
+++ b/proxies/shared/policies/JavaScript.SetBackendCorrelationId.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript async="false" continueOnError="false" enabled="true" timeLimit="200" name="JavaScript.SetBackendCorrelationId">
+    <DisplayName>JavaScript.SetBackendCorrelationId</DisplayName>
+    <Properties/>
+    <ResourceURL>jsc://SetBackendCorrelationId.js</ResourceURL>
+</Javascript>

--- a/proxies/shared/resources/jsc/SetBackendCorrelationId.js
+++ b/proxies/shared/resources/jsc/SetBackendCorrelationId.js
@@ -1,0 +1,8 @@
+const incomingCorrelationId = context.getVariable("request.header.x-correlation-id");
+const messageId = context.getVariable("messageid");
+
+if (incomingCorrelationId) {
+    context.setVariable("backendCorrelationId", incomingCorrelationId + "." + messageId);
+} else {
+    context.setVariable("backendCorrelationId", messageId);
+}


### PR DESCRIPTION
## Summary

Adds a step to extract the correlation identifier, if given, concatenating it onto the internal apigee request identifier.

This value is made available so it can be sent to the target backend.

Added the X-Correlation-Id header to the create message batches request.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
