### PR TITLE
CCM-1254: Removed randomness from tests

### DIFF
--- a/tests/development/create_message_batches/test_success.py
+++ b/tests/development/create_message_batches/test_success.py
@@ -1,15 +1,12 @@
 import requests
 import pytest
-import string
-import random
-import uuid
 from lib import Assertions, Generators
 
 VALID_ACCEPT_HEADERS = ["*/*", "application/json", "application/vnd.api+json"]
 VALID_CONTENT_TYPE_HEADERS = ["application/json", "application/vnd.api+json"]
 REQUEST_PATH = "/v1/message-batches"
 VALID_DOB = ["0000-01-01", "2023-01-01", None]
-valid_nhs_number = ''.join(random.choices(string.digits, k=10))
+valid_nhs_number = "0123456789"
 
 
 @pytest.mark.devtest

--- a/tests/sandbox/create_message_batches/test_success.py
+++ b/tests/sandbox/create_message_batches/test_success.py
@@ -1,7 +1,5 @@
 import requests
 import pytest
-import string
-import random
 from lib import Assertions, Generators
 
 VALID_ACCEPT_HEADERS = ["*/*", "application/json", "application/vnd.api+json"]
@@ -15,7 +13,7 @@ VALID_ROUTING_PLAN_ID = [
     "9ba00d23-cd6f-4aca-8688-00abc85a7980"
 ]
 VALID_DOB = ["0000-01-01", "2023-01-01", None]
-valid_nhs_number = ''.join(random.choices(string.digits, k=10))
+valid_nhs_number = "0123456789"
 
 
 @pytest.mark.sandboxtest


### PR DESCRIPTION
If we wanted a more secure RNG library for this we could replace `random` with `secrets`, but honestly the usage of randomness here is just to generate a 10 digit string of numbers for the mocked NHS number - there's absolutely no point in someone predicting this random value when literally any 10 digit string will work as a valid NHS number for the sandbox backend.

The main question is - do we even need the randomness in this test? We could just as easily use a hard-coded 10 digit string.

In this PR I've replaced the randomness with a fixed string.
