### PR TITLE
CCM-1604 - 406 documented response content type

### DIFF
--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -390,7 +390,7 @@ paths:
 
             Where no `Accept` header is present, this will default to `application/vnd.api+json`
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: '#/components/schemas/NotAcceptable'
           headers:

--- a/tests/development/content_types/test_406_errors.py
+++ b/tests/development/content_types/test_406_errors.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib import Assertions, Generators
+from lib.constants import DEFAULT_CONTENT_TYPE
 
 HEADER_NAME = ["accept", "ACCEPT", "Accept", "AcCePt"]
 HEADER_VALUE = ["", "application/xml", "image/png", "text/plain", "audio/mpeg", "xyz/abc"]
@@ -37,3 +38,5 @@ def test_406(
         Generators.generate_not_acceptable_error() if method not in ["options", "head"] else None,
         correlation_id
     )
+
+    assert resp.headers.get("Content-Type") == DEFAULT_CONTENT_TYPE

--- a/tests/integration/content_types/test_406_errors.py
+++ b/tests/integration/content_types/test_406_errors.py
@@ -33,3 +33,5 @@ def test_406(
         Generators.generate_not_acceptable_error() if method not in ["options", "head"] else None,
         correlation_id
     )
+
+    assert resp.headers.get("Content-Type") == DEFAULT_CONTENT_TYPE

--- a/tests/lib/constants.py
+++ b/tests/lib/constants.py
@@ -16,6 +16,7 @@ NUM_MAX_ERRORS = 100
 DEV_API_GATEWAY_URL = "https://comms-apim.internal-dev.communications.national.nhs.uk"
 INT_API_GATEWAY_URL = "https://comms-apim.int.communications.national.nhs.uk"
 PROD_API_GATEWAY_URL = "https://comms-apim.prod.communications.national.nhs.uk"
+DEFAULT_CONTENT_TYPE = "application/vnd.api+json"
 
 
 class Error():

--- a/tests/sandbox/content_types/test_406_errors.py
+++ b/tests/sandbox/content_types/test_406_errors.py
@@ -1,6 +1,7 @@
 import requests
 import pytest
 from lib import Assertions, Generators
+from lib.constants import DEFAULT_CONTENT_TYPE
 
 HEADER_NAME = ["accept", "ACCEPT", "Accept", "AcCePt"]
 HEADER_VALUE = ["", "application/xml", "image/png", "text/plain", "audio/mpeg", "xyz/abc"]
@@ -34,3 +35,5 @@ def test_406(
         Generators.generate_not_acceptable_error() if method not in ["options", "head"] else None,
         correlation_id
     )
+
+    assert resp.headers.get("Content-Type") == DEFAULT_CONTENT_TYPE


### PR DESCRIPTION
## Summary

Corrects the 406 response content type so it is set to application/vnd.api+json.

The reason why it is this, and not application/json is that our API outputs application/vnd.api+json by default.

On an unacceptable Accept header we must always respond with the default.

Adds an assertion on the 406 tests to ensure the default header is returned in the response.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
