### PR TITLE
CCM-15685: Removing REF2 References

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -76,23 +76,6 @@ extends:
             parameters:
               environment: 'ref'
               test_command: 'make internal-dev-test'
-      
-      - environment: ref
-        stage_name: ref2
-        service_name: "${{ variables.service_name }}-2"
-        short_service_name: "${{ variables.short_service_name }}-2"
-        service_base_path: "${{ variables.service_base_path }}-2"
-        depends_on:
-          - manual_approval_ref
-        jinja_templates:
-          ENVIRONMENT_TYPE: 'internal'
-          ERROR_ABOUT_LINK: ${{ variables.error_about_link }}
-          TARGET_SERVER_OVERRIDE: communications-manager-target-2
-        post_deploy:
-          - template: ./templates/run-tests.yml
-            parameters:
-              environment: 'ref2'
-              test_command: 'make internal-dev-test'
 
       - environment: manual-approval
         stage_name: manual_approval_internal_qa

--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -25,13 +25,6 @@ APIGEE_ENVIRONMENTS:
       app_quota: '108000'
       global_ratelimit: '108000pm'
       global_quota: '108000'
-    - name: 2-ref
-      display_name: Reference - 2
-      display_name: Reference
-      app_ratelimit: '108000pm'
-      app_quota: '108000'
-      global_ratelimit: '108000pm'
-      global_quota: '108000'
   - name: internal-dev-sandbox
     variants:
     - name: internal-dev-sandbox

--- a/tests/lib/authentication.py
+++ b/tests/lib/authentication.py
@@ -33,7 +33,7 @@ class AuthenticationCache():
         # a 404 response means the authentication is working.
         test_url = f"{base_url}/v1/messages/message_id"
 
-        if env in ["internal-dev", "internal-qa", "ref", "ref2"]:
+        if env in ["internal-dev", "internal-qa", "ref"]:
             api_key = os.environ["NON_PROD_API_KEY"]
             private_key = os.environ["NON_PROD_PRIVATE_KEY"]
             url = "https://internal-dev.api.service.nhs.uk/oauth2/token"

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -103,8 +103,8 @@ def url(api_product_name):
     environment = os.environ['API_ENVIRONMENT']
     if environment == "prod":
         return "https://api.service.nhs.uk/comms"
-    # authentication for ref and ref2 is shared with internal-dev
-    elif environment in ["ref", "ref2"]:
+    # authentication for ref is shared with internal-dev
+    elif environment in ["ref"]:
         return "https://internal-dev.api.service.nhs.uk/comms"
     else:
         return f"https://{environment}.api.service.nhs.uk/{suffix}"
@@ -115,9 +115,6 @@ def bearer_token(authentication_cache, api_product_in_comms_manager_local):
     environment = os.environ['API_ENVIRONMENT']
     if environment == "prod":
         url = PROD_URL
-    # the ref2 url is structured slightly differently so it needs to be explicitly called out here
-    elif environment == "ref2":
-        url = "https://ref.api.service.nhs.uk/comms-2"
     else:
         url = f"https://{environment}.api.service.nhs.uk/comms"
     return authentication_cache.generate_authentication(environment, url)


### PR DESCRIPTION
## Summary

The REF2 test environment has recently been decommissioned so pipelines and the codebase needs to no longer reference it

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
