### PR TITLE
CCM-17126: Fixed typo in GetMessage API docs

### DIFF
--- a/specification/documentation/GetMessage.md
+++ b/specification/documentation/GetMessage.md
@@ -63,15 +63,15 @@ Personalisation and contact details are not returned within the messages. This i
 
 ### Sandbox
 
-When sending this request on sandbox you can use one of these 5 message identifiers:
+When sending this request on sandbox you can use one of these 5 message references:
 
 * single message status of delivered - `2WL3qFTEFM0qMY8xjRbt1LIKCzM`
 * single message delivered using multiple channels - `2WL5eYSWGzCHlGmzNxuqVusPxDg`
 * single message status of sending - `2WL4GEeFVxXG9S57nRlefBwwKxp`
-* single message failed as patient has no exit code - `2WL4mvx6eBva8dcIK60VEGIfcgZ`
+* single message failed as patient has an exit code - `2WL4mvx6eBva8dcIK60VEGIfcgZ`
 * single message routing plan overriden - `2bBBpsiMl2rnQt99qm6JLZ6w1vq`
 
-Here's an example curl command using one of the above message Id's:
+Here's an example curl command using one of the above message references:
 
 ```
 curl -X GET 'https://sandbox.api.service.nhs.uk/comms/v1/messages/2WL3qFTEFM0qMY8xjRbt1LIKCzM' \


### PR DESCRIPTION
## Summary
Fixed a typo in the Get Message API docs for that message reference in sandbox that returns failure due to exit codes. Previously the description said "no exit codes":
<img width="1151" height="557" alt="image" src="https://github.com/user-attachments/assets/0b2ec707-a81c-4a94-a7b9-c1b5d2fc706d" />



## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
