### PR TITLE
CCM-17388: Change service level wording from Silver to Gold

### DIFF
--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -27,9 +27,9 @@ If you have any other queries, [contact us](https://digital.nhs.uk/developer/hel
 
 ## Service level
 
-This service is a [silver](https://digital.nhs.uk/services/reference-guide#service-levels) service, meaning it is available 24 hours a day, 365 days a year and supported from 8am to 6pm, Monday to Friday excluding bank holidays.
+This service is a [gold](https://digital.nhs.uk/services/reference-guide#service-levels) service, meaning it is available and supported 24 hours a day, 365 days a year.
 
-For more details, see [service levels](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#service-levels).
+For more details, including incident resolution times, see [service levels](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#service-levels).
 
 ## Technology
 


### PR DESCRIPTION
## Summary
NHS Notify moves from the Silver to Gold service level on Monday, 27th April. This change updates our public API documentation to reference Gold instead of Silver.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [x] Brief description of work completed, and any technical decisions made as part of the PR
* [x] PR link added as a comment to the relevant JIRA ticket
* [x] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
