### PR TITLE
CCM-19439: restrict which env vars are accessibile per environment

### DIFF
--- a/azure/templates/run-tests.yml
+++ b/azure/templates/run-tests.yml
@@ -4,7 +4,7 @@ parameters:
   - name: unit_test_report_name
     type: string
     default: ''
-  - name: nightly 
+  - name: nightly
     type: boolean
     default: false
   - name: environment
@@ -21,20 +21,24 @@ steps:
     parameters:
       secret_file_ids:
       - ptl/app-credentials/jwt_testing/non-prod/JWT_TESTING_PRIVATE_KEY
-      - ptl/api-deployment/communications-manager/NON_PROD_PRIVATE_KEY
-      - ptl/api-deployment/communications-manager/INTEGRATION_PRIVATE_KEY
-      - ptl/azure-devops/communications-manager/PRODUCTION_PRIVATE_KEY
+      - ${{ if eq(parameters.environment, 'prod') }}:
+        - ptl/azure-devops/communications-manager/PRODUCTION_PRIVATE_KEY
+      - ${{ else }}:
+        - ptl/api-deployment/communications-manager/INTEGRATION_PRIVATE_KEY
+        - ptl/api-deployment/communications-manager/NON_PROD_PRIVATE_KEY
       secret_ids:
       - ptl/app-credentials/communications-manager-testing-app/non-prod/SANDBOX_APP_ID
-      - ptl/api-deployment/communications-manager/NON_PROD_API_KEY
-      - ptl/api-deployment/communications-manager/NON_PROD_API_KEY_TEST_1
-      - ptl/api-deployment/communications-manager/INTEGRATION_API_KEY
-      - ptl/azure-devops/communications-manager/PRODUCTION_API_KEY
-      - ptl/api-deployment/communications-manager/GUKN_API_KEY
-      - ptl/api-deployment/communications-manager/UAT_GUKN_API_KEY
-      - ptl/api-deployment/communications-manager/UAT_NHS_APP_USERNAME
-      - ptl/api-deployment/communications-manager/UAT_NHS_APP_PASSWORD
-      - ptl/api-deployment/communications-manager/UAT_NHS_APP_OTP
+      - ${{ if eq(parameters.environment, 'prod') }}:
+        - ptl/azure-devops/communications-manager/PRODUCTION_API_KEY
+      - ${{ else }}:
+        - ptl/api-deployment/communications-manager/INTEGRATION_API_KEY
+        - ptl/api-deployment/communications-manager/NON_PROD_API_KEY
+        - ptl/api-deployment/communications-manager/NON_PROD_API_KEY_TEST_1
+        - ptl/api-deployment/communications-manager/GUKN_API_KEY
+        - ptl/api-deployment/communications-manager/UAT_GUKN_API_KEY
+        - ptl/api-deployment/communications-manager/UAT_NHS_APP_USERNAME
+        - ptl/api-deployment/communications-manager/UAT_NHS_APP_PASSWORD
+        - ptl/api-deployment/communications-manager/UAT_NHS_APP_OTP
   - bash: |
       if [ "${{ parameters.nightly }}" != "True" ]; then
         cd $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)
@@ -192,13 +196,18 @@ steps:
         export APIGEE_APP_ID="$(SANDBOX_APP_ID)"
         export STATUS_ENDPOINT_API_KEY="$(STATUS_ENDPOINT_API_KEY)"
         export SOURCE_COMMIT_ID="$(Build.SourceVersion)"
-        export NON_PROD_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(NON_PROD_PRIVATE_KEY)"
-        export NON_PROD_API_KEY="$(NON_PROD_API_KEY)"
-        export NON_PROD_API_KEY_TEST_1="$(NON_PROD_API_KEY_TEST_1)"
-        export INTEGRATION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(INTEGRATION_PRIVATE_KEY)"
-        export INTEGRATION_API_KEY="$(INTEGRATION_API_KEY)"
-        export PRODUCTION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(PRODUCTION_PRIVATE_KEY)"
-        export PRODUCTION_API_KEY="$(PRODUCTION_API_KEY)"
+
+        if [ "${{parameters.environment}}" = "prod" ]; then
+          export PRODUCTION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(PRODUCTION_PRIVATE_KEY)"
+          export PRODUCTION_API_KEY="$(PRODUCTION_API_KEY)"
+        else
+          export INTEGRATION_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(INTEGRATION_PRIVATE_KEY)"
+          export INTEGRATION_API_KEY="$(INTEGRATION_API_KEY)"
+          export NON_PROD_PRIVATE_KEY="$(Pipeline.Workspace)/secrets/$(NON_PROD_PRIVATE_KEY)"
+          export NON_PROD_API_KEY="$(NON_PROD_API_KEY)"
+          export NON_PROD_API_KEY_TEST_1="$(NON_PROD_API_KEY_TEST_1)"
+        fi
+
         ${{ parameters.test_command }}
       workingDirectory: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)
       displayName: Run test suite


### PR DESCRIPTION
## Summary

Stops prod accessing NON_PROD_PRIVATE_KEY in the run_tests.yml workflow. 


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
