### PR TITLE
CCM-21766: restrict _status monitoring to int/prod

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -35,8 +35,6 @@ extends:
     hosted_target_connection_path_suffix: ${{ variables.hosted_target_connection_path_suffix }}
     manual_approval_env: manual-approval-ptl
     prod_producer_approval: true
-    enable_monitoring: true
-    enable_status_monitoring: true
     apigee_deployments:
       - environment: internal-dev
         jinja_templates:
@@ -64,7 +62,7 @@ extends:
         stage_name: manual_approval_ref
         depends_on:
           - internal_dev
-            
+
       - environment: ref
         depends_on:
           - manual_approval_ref
@@ -140,6 +138,8 @@ extends:
       - environment: int
         depends_on:
           - manual_approval_int
+        enable_monitoring: true
+        enable_status_monitoring: true
         jinja_templates:
           ENVIRONMENT_TYPE: 'production'
           ERROR_ABOUT_LINK: ${{ variables.error_about_link }}
@@ -153,6 +153,8 @@ extends:
         depends_on:
           - int
           - sandbox
+        enable_monitoring: true
+        enable_status_monitoring: true
         jinja_templates:
           ENVIRONMENT_TYPE: 'production'
           ERROR_ABOUT_LINK: ${{ variables.error_about_link }}


### PR DESCRIPTION
## Summary

'Enable _status monitoring' is failing on internal_dev and internal_dev_sandbox due to new APIM environment requirements

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
