### PR TITLE
CCM-20515: switched client-provided URI placeholders to use curly brackets

### DIFF
--- a/scripts/perform-static-analysis.sh
+++ b/scripts/perform-static-analysis.sh
@@ -30,6 +30,8 @@ function main() {
 
 function create-report() {
 
+  rm -rf sandbox/coverage/tmp
+
   docker run --rm --platform linux/amd64 \
     --volume $PWD:/usr/src \
     sonarsource/sonar-scanner-cli:$image_version \

--- a/scripts/publish_zap_compatible.py
+++ b/scripts/publish_zap_compatible.py
@@ -44,6 +44,7 @@ with open('build/communications-manager-zap.json', 'w') as f:
                 ("personalisation", None),
                 ("/{client-provided-message-status-URI}", None),
                 ("/{client-provided-channel-status-URI}", None),
+                ("/{client-provided-recipient-response-URI}", None),
             )
         ),
         f

--- a/scripts/publish_zap_compatible.py
+++ b/scripts/publish_zap_compatible.py
@@ -42,8 +42,8 @@ with open('build/communications-manager-zap.json', 'w') as f:
             (
                 ("format", "date"),
                 ("personalisation", None),
-                ("/<client-provided-message-status-URI>", None),
-                ("/<client-provided-channel-status-URI>", None),
+                ("/{client-provided-message-status-URI}", None),
+                ("/{client-provided-channel-status-URI}", None),
             )
         ),
         f

--- a/specification/communications-manager.yaml
+++ b/specification/communications-manager.yaml
@@ -35,15 +35,15 @@ paths:
   /channels/nhsapp/accounts:
      get:
       $ref: endpoints/get_nhsapp_account_details.yaml
-  /<client-provided-message-status-URI>:
+  /{client-provided-message-status-URI}:
     post:
       $ref: callbacks/message_status.yaml
       tags: ['Callbacks']
-  /<client-provided-channel-status-URI>:
+  /{client-provided-channel-status-URI}:
     post:
       $ref: callbacks/channel_status.yaml
       tags: ['Callbacks']
-  /<client-provided-recipient-response-URI>:
+  /{client-provided-recipient-response-URI}:
     post:
       $ref: callbacks/recipient_response.yaml
       tags: ['Callbacks']

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -253,7 +253,7 @@ Answer options: [Yes, No]
 
 In order to present the recipient with answers, include the `answerOptions` field.
 
-If you subscribe to recipient response callbacks, NHS Notify will send you a callback when a recipient responds to a message (currently only NHS App supports this). See [the recipient response callback](#post-/<client-provided-recipient-response-URI>) for more details.
+If you subscribe to recipient response callbacks, NHS Notify will send you a callback when a recipient responds to a message (currently only NHS App supports this). See [the recipient response callback](#post-/{client-provided-recipient-response-URI}) for more details.
 
 ## Message character limits
 Different character limits apply to each of the communication channels as listed below. NHS Notify will validate that any personalisation fields submitted in the send message request do not exceed these limits but it is the client's responsibility to ensure that when personalisation is combined with any templated text, the channel character limit is not exceeded.

--- a/specification/documentation/APIDescription.md
+++ b/specification/documentation/APIDescription.md
@@ -253,7 +253,7 @@ Answer options: [Yes, No]
 
 In order to present the recipient with answers, include the `answerOptions` field.
 
-If you subscribe to recipient response callbacks, NHS Notify will send you a callback when a recipient responds to a message (currently only NHS App supports this). See [the recipient response callback](#post-/{client-provided-recipient-response-URI}) for more details.
+If you subscribe to recipient response callbacks, NHS Notify will send you a callback when a recipient responds to a message (currently only NHS App supports this). See [the recipient response callback](#post-/-client-provided-recipient-response-URI-) for more details.
 
 ## Message character limits
 Different character limits apply to each of the communication channels as listed below. NHS Notify will validate that any personalisation fields submitted in the send message request do not exceed these limits but it is the client's responsibility to ensure that when personalisation is combined with any templated text, the channel character limit is not exceeded.

--- a/specification/schemas/components/RecipientResponse.yaml
+++ b/specification/schemas/components/RecipientResponse.yaml
@@ -69,13 +69,13 @@ properties:
   links:
     type: object
     properties:
-      recipientResponse:
+      messageResponses:
         type: string
         description: URL to retrieve the recipient response details.
         format: uri
-        example: "https://api.service.nhs.uk/comms/v1/messages/2WL3qFTEFM0qMY8xjRbt1LIKCzM/recipient-response/33333333-3333-4333-8333-333333333333"
+        example: "https://api.service.nhs.uk/comms/v1/message-responses/2WL3qFTEFM0qMY8xjRbt1LIKCzM"
     required:
-      - recipientResponse
+      - messageResponses
   meta:
     type: object
     properties:


### PR DESCRIPTION
## Summary

The use of angle brackets (`<` and `>`) in placeholders for client-provided callback endpoint URIs has caused problems with the pages for those endpoints and links to them which are embedded in markdown. 


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Checklist
* [ ] Brief description of work completed, and any technical decisions made as part of the PR
* [ ] PR link added as a comment to the relevant JIRA ticket
* [ ] PR link shared on Slack and/or Teams
* [ ] 2 reviews received
* [ ] Tester approval
